### PR TITLE
[FEAT] 매매 조회 API 구현

### DIFF
--- a/src/main/java/org/invemotion/controller/TradeController.java
+++ b/src/main/java/org/invemotion/controller/TradeController.java
@@ -1,0 +1,43 @@
+package org.invemotion.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.invemotion.dto.response.TradeListData;
+import org.invemotion.dto.response.TradeResponse;
+import org.invemotion.global.dto.PageResponse;
+import org.invemotion.global.dto.SuccessResponse;
+import org.invemotion.global.dto.enums.SuccessCode;
+import org.invemotion.service.TradeQueryService;
+import org.springframework.data.domain.*;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+
+@RestController
+@RequestMapping("/api/trades")
+@RequiredArgsConstructor
+public class TradeController{
+
+    private final TradeQueryService tradeQueryService;
+
+    @GetMapping
+    public ResponseEntity<SuccessResponse<TradeListData>> list(
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM") YearMonth month,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        LocalDateTime start = month.atDay(1).atStartOfDay();
+        LocalDateTime end   = month.plusMonths(1).atDay(1).atStartOfDay();
+        Pageable pageable   = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "completedTime"));
+
+        PageResponse<TradeResponse> pageDto =
+                tradeQueryService.getTradePage(userId, start, end, pageable);
+
+        return ResponseEntity
+                .status(SuccessCode.OK.getHttpStatus())
+                .body(SuccessResponse.of(SuccessCode.OK, new TradeListData(pageDto)));
+    }
+}

--- a/src/main/java/org/invemotion/controller/docs/TradeApiControllerApiDocs.java
+++ b/src/main/java/org/invemotion/controller/docs/TradeApiControllerApiDocs.java
@@ -1,0 +1,4 @@
+package org.invemotion.controller.docs;
+
+public interface TradeApiControllerApiDocs {
+}

--- a/src/main/java/org/invemotion/domain/trade/Trade.java
+++ b/src/main/java/org/invemotion/domain/trade/Trade.java
@@ -68,7 +68,7 @@ public class Trade {
     @Column(name = "quantity", nullable = false)
     private Integer quantity;
 
-    @Column(name = "total_amount", nullable = false)
-    private Integer totalAmount;
+    @Column(name = "total_amount", precision = 20, scale = 4, nullable = false)
+    private BigDecimal totalAmount;
 }
 

--- a/src/main/java/org/invemotion/dto/response/TradeListData.java
+++ b/src/main/java/org/invemotion/dto/response/TradeListData.java
@@ -1,0 +1,6 @@
+package org.invemotion.dto.response;
+
+import org.invemotion.global.dto.PageResponse;
+
+public record TradeListData(PageResponse<TradeResponse> trades) {
+}

--- a/src/main/java/org/invemotion/dto/response/TradeResponse.java
+++ b/src/main/java/org/invemotion/dto/response/TradeResponse.java
@@ -1,0 +1,28 @@
+package org.invemotion.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record TradeResponse(
+        Long id,
+        UUID tradeId,
+        String stockName,
+        String stockCode,
+        String actionType,
+        String orderType,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime orderTime,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime completedTime,
+        BigDecimal marketPriceAtOrder,
+        BigDecimal pricePerBuy,
+        BigDecimal pricePerSell,
+        Integer quantity,
+        BigDecimal totalAmount,
+        String resultType,
+        BigDecimal exchangeRate
+) {
+}

--- a/src/main/java/org/invemotion/global/dto/ErrorResponse.java
+++ b/src/main/java/org/invemotion/global/dto/ErrorResponse.java
@@ -1,0 +1,14 @@
+package org.invemotion.global.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.invemotion.global.dto.enums.ErrorCode;
+
+@Schema(description = "오류 응답")
+public record ErrorResponse(
+        @Schema(description = "에러 코드", example = "40000") int status,
+        @Schema(description = "에러 메시지", example = "요청 필드가 잘못되었습니다.") String message
+) {
+    public static ErrorResponse of(ErrorCode code) {
+        return new ErrorResponse(code.getCode(), code.getMessage());
+    }
+}

--- a/src/main/java/org/invemotion/global/dto/PageResponse.java
+++ b/src/main/java/org/invemotion/global/dto/PageResponse.java
@@ -1,0 +1,11 @@
+package org.invemotion.global.dto;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        boolean last
+) {}

--- a/src/main/java/org/invemotion/global/dto/SuccessResponse.java
+++ b/src/main/java/org/invemotion/global/dto/SuccessResponse.java
@@ -1,0 +1,21 @@
+package org.invemotion.global.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.invemotion.global.dto.enums.SuccessCode;
+
+@Schema(description = "성공 응답")
+public record SuccessResponse<T>(
+        @Schema(description = "업무 상태 코드", example = "20000")
+        int status,
+        @Schema(description = "성공 메시지", example = "요청이 성공적으로 처리되었습니다.")
+        String message,
+        @Schema(description = "실제 데이터") T data
+) {
+    public static <T> SuccessResponse<T> of(SuccessCode code, T data) {
+        return new SuccessResponse<>(code.getCode(), code.getMessage(), data);
+    }
+
+    public static SuccessResponse<Void> of(SuccessCode code) {
+        return new SuccessResponse<>(code.getCode(), code.getMessage(), null);
+    }
+}

--- a/src/main/java/org/invemotion/global/dto/enums/ErrorCode.java
+++ b/src/main/java/org/invemotion/global/dto/enums/ErrorCode.java
@@ -1,0 +1,41 @@
+package org.invemotion.global.dto.enums;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+    // Trade
+    MISSING_PERIOD             (HttpStatus.BAD_REQUEST, 40005, "조회 기간(start/end)이 누락되었습니다."),
+    INVALID_PERIOD_RANGE       (HttpStatus.BAD_REQUEST, 40006, "start는 end보다 이전이어야 합니다."),
+
+
+    // Bond_Purchase
+    PURCHASE_NOT_FOUND (HttpStatus.NOT_FOUND, 40010, "해당 매입 거래를 찾을 수 없습니다."),
+    PURCHASE_ALREADY_CANCELED (HttpStatus.CONFLICT, 40011, "이미 취소된 거래입니다."),
+
+
+    // 공용
+    INVALID_REQUEST (HttpStatus.BAD_REQUEST, 40000, "요청 필드가 잘못되었습니다."),
+    MISSING_USER_ID_HEADER     (HttpStatus.BAD_REQUEST, 40001, "X-User-Id 헤더가 누락되었습니다."),
+    INVALID_TAG (HttpStatus.NOT_FOUND, 40400, "해당 태그가 존재하지 않습니다."),
+    CONCURRENT_UPDATE (HttpStatus.PRECONDITION_FAILED,     41200, "수정하려는 정보가 최신 상태가 아닙니다."),
+    IF_MATCH_REQUIRED (HttpStatus.PRECONDITION_REQUIRED,   42800, "If-Match 헤더(버전 정보)가 누락되었습니다."),
+    INTERNAL_ERROR (HttpStatus.INTERNAL_SERVER_ERROR, 50000, "서버 내부 오류입니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, int code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    public HttpStatus getHttpStatus() { return httpStatus; }
+    public int getCode() { return code; }
+    public String getMessage() { return message; }
+}
+
+
+

--- a/src/main/java/org/invemotion/global/dto/enums/SuccessCode.java
+++ b/src/main/java/org/invemotion/global/dto/enums/SuccessCode.java
@@ -1,0 +1,22 @@
+package org.invemotion.global.dto.enums;
+
+import org.springframework.http.HttpStatus;
+
+public enum SuccessCode {
+    OK(HttpStatus.OK, 200, "요청이 성공적으로 처리되었습니다."),
+    CREATED(HttpStatus.CREATED, 201, "성공적으로 생성되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    SuccessCode(HttpStatus httpStatus, int code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    public HttpStatus getHttpStatus() { return httpStatus; }
+    public int getCode() { return code; }
+    public String getMessage() { return message; }
+}

--- a/src/main/java/org/invemotion/global/exception/CustomException.java
+++ b/src/main/java/org/invemotion/global/exception/CustomException.java
@@ -1,0 +1,22 @@
+package org.invemotion.global.exception;
+
+import org.invemotion.global.dto.enums.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return errorCode.getHttpStatus();
+    }
+}

--- a/src/main/java/org/invemotion/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/invemotion/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,76 @@
+package org.invemotion.global.exception;
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import jakarta.persistence.OptimisticLockException;
+import org.invemotion.global.dto.ErrorResponse;
+import org.invemotion.global.dto.enums.ErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleJsonParseErrors(HttpMessageNotReadableException e) {
+        Throwable cause = e.getCause();
+
+        if (cause instanceof InvalidFormatException invalidFormatException) {
+            if (invalidFormatException.getTargetType().isEnum()) {
+                return ResponseEntity
+                        .status(ErrorCode.INVALID_TAG.getHttpStatus())
+                        .body(ErrorResponse.of(ErrorCode.INVALID_TAG));
+            }
+        }
+
+        if (cause instanceof UnrecognizedPropertyException) {
+            return ResponseEntity
+                    .status(ErrorCode.INVALID_REQUEST.getHttpStatus())
+                    .body(ErrorResponse.of(ErrorCode.INVALID_REQUEST));
+        }
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(ErrorCode.INTERNAL_ERROR));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnknownException(Exception e) {
+        e.printStackTrace();
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(ErrorCode.INTERNAL_ERROR));
+    }
+
+    @ExceptionHandler(OptimisticLockException.class)
+    public ResponseEntity<ErrorResponse> handleOptimisticLock(OptimisticLockException e) {
+        return ResponseEntity
+                .status(HttpStatus.PRECONDITION_FAILED)
+                .body(ErrorResponse.of(ErrorCode.CONCURRENT_UPDATE));
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<ErrorResponse> handleMissingIfMatch(MissingRequestHeaderException e) {
+        if ("If-Match".equals(e.getHeaderName())) {
+            return ResponseEntity
+                    .status(HttpStatus.PRECONDITION_REQUIRED)
+                    .body(ErrorResponse.of(ErrorCode.IF_MATCH_REQUIRED));
+        }
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(ErrorCode.INVALID_REQUEST));
+    }
+}

--- a/src/main/java/org/invemotion/repository/TradeRepository.java
+++ b/src/main/java/org/invemotion/repository/TradeRepository.java
@@ -1,0 +1,21 @@
+package org.invemotion.repository;
+
+import org.invemotion.domain.trade.Trade;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+
+public interface TradeRepository extends JpaRepository<Trade, Long> {
+
+    @Query("""
+        select t from Trade t
+        where t.user.userId = :userId
+          and t.completedTime is not null
+          and t.completedTime >= :start
+          and t.completedTime <  :end
+    """)
+    Page<Trade> findPageByUserAndCompletedBetween(Long userId, LocalDateTime start, LocalDateTime end, Pageable pageable);
+}

--- a/src/main/java/org/invemotion/service/TradeQueryService.java
+++ b/src/main/java/org/invemotion/service/TradeQueryService.java
@@ -1,0 +1,85 @@
+package org.invemotion.service;
+
+import lombok.RequiredArgsConstructor;
+import org.invemotion.domain.trade.Trade;
+import org.invemotion.domain.trade.enums.ActionType;
+import org.invemotion.domain.trade.enums.OrderType;
+import org.invemotion.domain.trade.enums.ResultType;
+import org.invemotion.dto.response.TradeResponse;
+import org.invemotion.global.dto.PageResponse;
+import org.invemotion.repository.TradeRepository;
+import org.invemotion.service.validator.TradeQueryValidator;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TradeQueryService {
+
+    private final TradeRepository tradeRepository;
+    private final TradeQueryValidator validator;
+
+    public PageResponse<TradeResponse> getTradePage(
+            Long userId, LocalDateTime start, LocalDateTime end, Pageable pageable
+    ) {
+        validator.validateUser(userId);
+        validator.validatePeriod(start, end);
+
+        Page<Trade> p = tradeRepository.findPageByUserAndCompletedBetween(userId, start, end, pageable);
+
+        List<TradeResponse> items = p.getContent().stream()
+                .map(this::toDto)
+                .toList();
+
+        return new PageResponse<>(items, p.getNumber(), p.getSize(), p.getTotalElements(), p.isLast());
+    }
+
+    private TradeResponse toDto(Trade t) {
+        return new TradeResponse(
+                t.getId(),
+                t.getTradeUUID(),
+                t.getSymbolName(),
+                t.getSymbolCode(),
+                label(t.getActionType()),
+                label(t.getOrderType()),
+                t.getOrderTime(),
+                t.getCompletedTime(),
+                t.getMarketPriceAtOrder(),
+                t.getPricePerBuy(),
+                t.getPricePerSell(),
+                t.getQuantity(),
+                t.getTotalAmount(),
+                label(t.getResultType()),
+                t.getExchangeRate()
+        );
+    }
+
+    private String label(ActionType a) {
+        return switch (a) {
+            case BUY  -> "매수";
+            case SELL -> "매도";
+        };
+    }
+
+    private String label(OrderType o) {
+        return switch (o) {
+            case MARKET -> "시장가";
+            case LIMIT  -> "지정가";
+        };
+    }
+
+    private String label(ResultType r) {
+        if (r == null) return null;
+        return switch (r) {
+            case BREAK_EVEN -> "본전";
+            case PROFIT     -> "수익";
+            case LOSS       -> "손실";
+        };
+    }
+}

--- a/src/main/java/org/invemotion/service/validator/TradeQueryValidator.java
+++ b/src/main/java/org/invemotion/service/validator/TradeQueryValidator.java
@@ -1,0 +1,28 @@
+// src/main/java/org/invemotion/service/validator/TradeQueryValidator.java
+package org.invemotion.service.validator;
+
+import org.invemotion.global.dto.enums.ErrorCode;
+import org.invemotion.global.exception.CustomException;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class TradeQueryValidator {
+
+    public void validateUser(Long userId) {
+        if (userId == null) {
+            throw new CustomException(ErrorCode.MISSING_USER_ID_HEADER);
+        }
+    }
+
+    public void validatePeriod(LocalDateTime start, LocalDateTime end) {
+        if (start == null || end == null) {
+            throw new CustomException(ErrorCode.MISSING_PERIOD);
+        }
+        if (!start.isBefore(end)) {
+            throw new CustomException(ErrorCode.INVALID_PERIOD_RANGE);
+        }
+    }
+}
+


### PR DESCRIPTION
## Related issue 🛠
- closed #3 

## Work Description ✏️
- 사용자 별, 해당 월 별 매매 조회 API 구현

## Screenshot 📸

## To Reviewers 📢
- page 처리 (불필요 시, 삭제 필요)
- 날짜 빠른 순으로 조회 가능