### PR TITLE
[FEAT] 매매 일지 관련 API 구현

### DIFF
--- a/src/main/java/org/invemotion/controller/JournalController.java
+++ b/src/main/java/org/invemotion/controller/JournalController.java
@@ -1,0 +1,64 @@
+package org.invemotion.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.invemotion.domain.journal.Journal;
+import org.invemotion.dto.request.JournalCreateRequest;
+import org.invemotion.dto.request.JournalUpdateRequest;
+import org.invemotion.dto.response.JournalCreateResponse;
+import org.invemotion.dto.response.JournalListData;
+import org.invemotion.dto.response.JournalResponse;
+import org.invemotion.dto.response.TradeListData;
+import org.invemotion.global.dto.SuccessResponse;
+import org.invemotion.global.dto.enums.SuccessCode;
+import org.invemotion.service.JournalCommandService;
+import org.invemotion.service.JournalQueryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class JournalController {
+
+    private final JournalCommandService journalCommandService;
+    private final JournalQueryService journalQueryService;
+
+    @PostMapping("trades/{tradeId}/journal")
+    public ResponseEntity<SuccessResponse<JournalResponse>> create(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long tradeId,
+            @Valid @RequestBody JournalCreateRequest request
+    ) {
+        Journal journal = journalCommandService.create(userId, tradeId, request);
+        JournalResponse body = journalQueryService.getById(userId, journal.getId());
+        return ResponseEntity
+                .status(SuccessCode.OK.getHttpStatus())
+                .body(SuccessResponse.of(SuccessCode.OK, body));
+    }
+
+    @GetMapping("journals/{id}")
+    public ResponseEntity<SuccessResponse<JournalResponse>> getJournal(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id
+    ){
+        JournalResponse journal = journalQueryService.getById(userId, id);
+
+        return ResponseEntity
+                .status(SuccessCode.OK.getHttpStatus())
+                .body(SuccessResponse.of(SuccessCode.OK, journal));
+    }
+
+    @PutMapping("journals/{id}")
+    public ResponseEntity<SuccessResponse<JournalResponse>> update(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id,
+            @Valid @RequestBody JournalUpdateRequest request
+    ) {
+        journalCommandService.update(userId, id, request);
+        JournalResponse body = journalQueryService.getById(userId, id);
+        return ResponseEntity
+                .status(SuccessCode.OK.getHttpStatus())
+                .body(SuccessResponse.of(SuccessCode.OK, body));
+    }
+}

--- a/src/main/java/org/invemotion/domain/journal/Journal.java
+++ b/src/main/java/org/invemotion/domain/journal/Journal.java
@@ -3,11 +3,14 @@ package org.invemotion.domain.journal;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.invemotion.domain.journal.enums.*;
 import org.invemotion.domain.trade.Trade;
 import org.invemotion.domain.user.User;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Getter
 @Entity
@@ -44,5 +47,37 @@ public class Journal {
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name="updated_at")
+    private LocalDateTime updatedAt;
+
+
+    @PrePersist
+    @PreUpdate
+    private void normalize() {
+        if (reason != null) {
+            reason = reason.trim();
+        }
+    }
+
+    public boolean update(String reason, Emotion emotion, BehaviorType behavior) {
+        boolean changed = false;
+
+        if (!this.reason.equals(reason)) {
+            this.reason = reason;
+            changed = true;
+        }
+        if (this.emotion != emotion) {
+            this.emotion = emotion;
+            changed = true;
+        }
+        if (this.behavior != behavior) {
+            this.behavior = behavior;
+            changed = true;
+        }
+
+        return changed;
+    }
 }
 

--- a/src/main/java/org/invemotion/dto/request/JournalCreateRequest.java
+++ b/src/main/java/org/invemotion/dto/request/JournalCreateRequest.java
@@ -1,0 +1,19 @@
+package org.invemotion.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.invemotion.domain.journal.enums.BehaviorType;
+import org.invemotion.domain.journal.enums.Emotion;
+
+public record JournalCreateRequest(
+        @NotBlank
+        String reason,
+
+        @NotNull
+        Emotion emotion,
+
+        @NotNull
+        BehaviorType behavior
+) {
+}

--- a/src/main/java/org/invemotion/dto/request/JournalUpdateRequest.java
+++ b/src/main/java/org/invemotion/dto/request/JournalUpdateRequest.java
@@ -1,0 +1,18 @@
+package org.invemotion.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.invemotion.domain.journal.enums.BehaviorType;
+import org.invemotion.domain.journal.enums.Emotion;
+
+public record JournalUpdateRequest(
+        @NotBlank
+        String reason,
+
+        @NotNull
+        Emotion emotion,
+
+        @NotNull
+        BehaviorType behavior
+) {
+}

--- a/src/main/java/org/invemotion/dto/response/JournalCreateResponse.java
+++ b/src/main/java/org/invemotion/dto/response/JournalCreateResponse.java
@@ -1,0 +1,10 @@
+package org.invemotion.dto.response;
+
+import org.invemotion.domain.journal.enums.BehaviorType;
+import org.invemotion.domain.journal.enums.Emotion;
+import org.invemotion.domain.trade.enums.ResultType;
+
+public record JournalCreateResponse(
+        Long id
+) {
+}

--- a/src/main/java/org/invemotion/dto/response/JournalListData.java
+++ b/src/main/java/org/invemotion/dto/response/JournalListData.java
@@ -1,0 +1,6 @@
+package org.invemotion.dto.response;
+
+import org.invemotion.global.dto.PageResponse;
+
+public record JournalListData(PageResponse<JournalResponse> Journals) {
+}

--- a/src/main/java/org/invemotion/dto/response/JournalResponse.java
+++ b/src/main/java/org/invemotion/dto/response/JournalResponse.java
@@ -1,0 +1,14 @@
+package org.invemotion.dto.response;
+
+import org.invemotion.domain.journal.enums.BehaviorType;
+import org.invemotion.domain.journal.enums.Emotion;
+
+public record JournalResponse(
+        Long id,
+        Long tradeId,
+        Long userId,
+        String reason,
+        Emotion emotion,
+        BehaviorType behavior
+) {
+}

--- a/src/main/java/org/invemotion/dto/response/TradeResponse.java
+++ b/src/main/java/org/invemotion/dto/response/TradeResponse.java
@@ -23,6 +23,8 @@ public record TradeResponse(
         Integer quantity,
         BigDecimal totalAmount,
         String resultType,
-        BigDecimal exchangeRate
+        BigDecimal exchangeRate,
+        boolean hasJournal,
+        Long journalId
 ) {
 }

--- a/src/main/java/org/invemotion/global/dto/enums/ErrorCode.java
+++ b/src/main/java/org/invemotion/global/dto/enums/ErrorCode.java
@@ -4,18 +4,19 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
     // Trade
-    MISSING_PERIOD             (HttpStatus.BAD_REQUEST, 40005, "조회 기간(start/end)이 누락되었습니다."),
-    INVALID_PERIOD_RANGE       (HttpStatus.BAD_REQUEST, 40006, "start는 end보다 이전이어야 합니다."),
+    MISSING_PERIOD (HttpStatus.BAD_REQUEST, 40005, "조회 기간(start/end)이 누락되었습니다."),
+    INVALID_PERIOD_RANGE (HttpStatus.BAD_REQUEST, 40006, "start는 end보다 이전이어야 합니다."),
+    TRADE_NOT_FOUND_OR_NOT_OWNED (HttpStatus.NOT_FOUND, 40007, "요청하신 거래를 찾을 수 없거나 권한이 없습니다."),
 
 
-    // Bond_Purchase
-    PURCHASE_NOT_FOUND (HttpStatus.NOT_FOUND, 40010, "해당 매입 거래를 찾을 수 없습니다."),
-    PURCHASE_ALREADY_CANCELED (HttpStatus.CONFLICT, 40011, "이미 취소된 거래입니다."),
-
+    // Journal
+    JOURNAL_ALREADY_EXISTS(HttpStatus.CONFLICT, 40901, "해당 거래의 매매 일지가 이미 존재합니다."),
+    JOURNAL_NOT_FOUND_OR_NOT_OWNED (HttpStatus.NOT_FOUND, 40902, "요청하신 거래를 찾을 수 없거나 권한이 없습니다."),
+    JOURNAL_NOT_MODIFIED(HttpStatus.BAD_REQUEST, 40903, "변경사항이 없습니다."),
 
     // 공용
     INVALID_REQUEST (HttpStatus.BAD_REQUEST, 40000, "요청 필드가 잘못되었습니다."),
-    MISSING_USER_ID_HEADER     (HttpStatus.BAD_REQUEST, 40001, "X-User-Id 헤더가 누락되었습니다."),
+    MISSING_USER_ID_HEADER (HttpStatus.BAD_REQUEST, 40001, "X-User-Id 헤더가 누락되었습니다."),
     INVALID_TAG (HttpStatus.NOT_FOUND, 40400, "해당 태그가 존재하지 않습니다."),
     CONCURRENT_UPDATE (HttpStatus.PRECONDITION_FAILED,     41200, "수정하려는 정보가 최신 상태가 아닙니다."),
     IF_MATCH_REQUIRED (HttpStatus.PRECONDITION_REQUIRED,   42800, "If-Match 헤더(버전 정보)가 누락되었습니다."),

--- a/src/main/java/org/invemotion/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/invemotion/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import jakarta.persistence.OptimisticLockException;
 import org.invemotion.global.dto.ErrorResponse;
 import org.invemotion.global.dto.enums.ErrorCode;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -72,5 +73,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of(ErrorCode.INVALID_REQUEST));
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrity(DataIntegrityViolationException e) {
+        return ResponseEntity
+                .status(ErrorCode.JOURNAL_ALREADY_EXISTS.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.JOURNAL_ALREADY_EXISTS));
     }
 }

--- a/src/main/java/org/invemotion/repository/JournalRepository.java
+++ b/src/main/java/org/invemotion/repository/JournalRepository.java
@@ -1,0 +1,28 @@
+package org.invemotion.repository;
+
+import org.invemotion.domain.journal.Journal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface JournalRepository extends JpaRepository<Journal, Long> {
+
+    @Query("""
+        select j.trade.id as tradeId, j.id as id
+        from Journal j
+        where j.trade.id in :tradeIds
+    """)
+    List<TradeJournalPair> findJournalIdsByTradeIds(Collection<Long> tradeIds);
+
+    boolean existsByIdAndUser_UserId(Long id, Long userId);
+
+    interface TradeJournalPair {
+        Long getTradeId();
+        Long getId();
+    }
+
+    Optional<Journal> findByIdAndUser_UserId(Long id, Long userId);
+}

--- a/src/main/java/org/invemotion/repository/TradeRepository.java
+++ b/src/main/java/org/invemotion/repository/TradeRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
 
 public interface TradeRepository extends JpaRepository<Trade, Long> {
 
@@ -18,4 +20,6 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
           and t.completedTime <  :end
     """)
     Page<Trade> findPageByUserAndCompletedBetween(Long userId, LocalDateTime start, LocalDateTime end, Pageable pageable);
+
+    boolean existsByIdAndUser_UserId(Long id, Long userId);
 }

--- a/src/main/java/org/invemotion/service/JournalCommandService.java
+++ b/src/main/java/org/invemotion/service/JournalCommandService.java
@@ -1,0 +1,64 @@
+package org.invemotion.service;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.invemotion.domain.journal.Journal;
+import org.invemotion.domain.trade.Trade;
+import org.invemotion.domain.user.User;
+import org.invemotion.dto.request.JournalCreateRequest;
+import org.invemotion.dto.request.JournalUpdateRequest;
+import org.invemotion.global.dto.enums.ErrorCode;
+import org.invemotion.global.exception.CustomException;
+import org.invemotion.repository.JournalRepository;
+import org.invemotion.repository.TradeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class JournalCommandService {
+
+    private final TradeRepository tradeRepository;
+    private final JournalRepository journalRepository;
+    private final EntityManager em;
+
+    @Transactional
+    public Journal create(Long userId, Long tradeId, JournalCreateRequest req) {
+        validateTradeOwnership(tradeId, userId);
+        User  userRef  = em.getReference(User.class,  userId);
+        Trade tradeRef = em.getReference(Trade.class, tradeId);
+
+        Journal journal = Journal.builder()
+                .user(userRef)
+                .trade(tradeRef)
+                .reason(req.reason())
+                .emotion(req.emotion())
+                .behavior(req.behavior())
+                .build();
+
+        return journalRepository.save(journal);
+    }
+
+    @Transactional
+    public void update(Long userId, Long id, JournalUpdateRequest req){
+        validateJournalOwnership(id, userId);
+
+        Journal journal = journalRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.JOURNAL_NOT_FOUND_OR_NOT_OWNED));
+
+        boolean changed = journal.update(req.reason(), req.emotion(), req.behavior());
+        if (!changed) {
+            throw new CustomException(ErrorCode.JOURNAL_NOT_MODIFIED);
+        }
+    }
+
+    private void validateTradeOwnership(Long tradeId, Long userId) {
+        boolean owned = tradeRepository.existsByIdAndUser_UserId(tradeId, userId);
+        if (!owned) throw new CustomException(ErrorCode.TRADE_NOT_FOUND_OR_NOT_OWNED);
+    }
+
+    private void validateJournalOwnership(Long id, Long userId) {
+        boolean owned = journalRepository.existsByIdAndUser_UserId(id, userId);
+        if (!owned) throw new CustomException(ErrorCode.JOURNAL_NOT_FOUND_OR_NOT_OWNED);
+    }
+}

--- a/src/main/java/org/invemotion/service/JournalQueryService.java
+++ b/src/main/java/org/invemotion/service/JournalQueryService.java
@@ -1,0 +1,36 @@
+package org.invemotion.service;
+
+import lombok.RequiredArgsConstructor;
+import org.invemotion.domain.journal.Journal;
+import org.invemotion.dto.response.JournalResponse;
+import org.invemotion.global.dto.enums.ErrorCode;
+import org.invemotion.global.exception.CustomException;
+import org.invemotion.repository.JournalRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class JournalQueryService {
+
+    private final JournalRepository journalRepository;
+
+    public JournalResponse getById(
+            Long userId,
+            Long id
+    ){
+        var j = journalRepository.findByIdAndUser_UserId(id, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.JOURNAL_NOT_FOUND_OR_NOT_OWNED));
+        return new JournalResponse(
+                j.getId(),
+                j.getTrade().getId(),
+                j.getUser().getUserId(),
+                j.getReason(),
+                j.getEmotion(),
+                j.getBehavior()
+        );
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #5 

## Work Description ✏️
- 매매 일지 생성 API
- 개별 매매 일지 조회 API
- 매매 일지 수정 API


## Screenshot 📸

## To Reviewers 📢
- 매매 거래 list 조회 시, 일지 작성 여부, 작성했다면 일지 ID 까지 함께 전달되도록 변경